### PR TITLE
Scale the number of Verdi worker nodes in the Kubernetes cluster

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,15 +3,17 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
 from mangum import Mangum
+import asyncio
 
 from .routers import prewarm
 
+asyncio.create_task(prewarm.process_prewarm_queue())
 
 app = FastAPI(
-        title="Unity SPS REST API",
-        version="0.0.1",
-        description="Unity SPS Operations",
-        root_path=f"/{os.environ.get('STAGE')}/" if "STAGE" in os.environ else None
+    title="Unity SPS REST API",
+    version="0.0.1",
+    description="Unity SPS Operations",
+    root_path=f"/{os.environ.get('STAGE')}/" if "STAGE" in os.environ else None,
 )
 
 app.add_middleware(

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,12 @@ app = FastAPI(
     root_path=f"/{os.environ.get('STAGE')}/" if "STAGE" in os.environ else None,
 )
 
+
+@app.on_event("startup")
+async def startup_event():
+    asyncio.create_task(prewarm.process_prewarm_queue())
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_credentials=True,

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,6 @@ import asyncio
 
 from .routers import prewarm
 
-asyncio.create_task(prewarm.process_prewarm_queue())
 
 app = FastAPI(
     title="Unity SPS REST API",

--- a/app/main.py
+++ b/app/main.py
@@ -1,12 +1,11 @@
-import os
-from fastapi import Depends, FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.utils import get_openapi
-from mangum import Mangum
 import asyncio
+import os
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from mangum import Mangum
 
 from .routers import prewarm
-
 
 app = FastAPI(
     title="Unity SPS REST API",

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -79,7 +79,7 @@ def is_valid_desired_size(func):
     @wraps(func)
     def wrapper(req):
         try:
-            eks = boto3.client("eks")
+            eks = boto3.client("eks", region_name="us-west-2")
             current_max_size = 0
             response = eks.describe_nodegroup(
                 clusterName=req.cluster_name,
@@ -93,7 +93,7 @@ def is_valid_desired_size(func):
                 return ScaleResponse(
                     success=False,
                     message=f"Desired size {req.desired_size} is larger than current max size {current_max_size}",
-                    nodegroup_update=None,
+                    nodegroup_update={},
                 )
             else:
                 return func(req)
@@ -101,13 +101,13 @@ def is_valid_desired_size(func):
             return ScaleResponse(
                 success=False,
                 message=f"Error occurred while checking desired size: {str(e)}",
-                nodegroup_update=None,
+                nodegroup_update={},
             )
         except Exception as e:
             return ScaleResponse(
                 success=False,
                 message=f"Unexpected error occurred while checking desired size: {str(e)}",
-                nodegroup_update=None,
+                nodegroup_update={},
             )
 
     return wrapper
@@ -117,7 +117,7 @@ def is_valid_desired_size(func):
 @is_valid_desired_size
 def update_nodegroup_size(req: ScaleRequest) -> ScaleResponse:
     try:
-        eks = boto3.client("eks")
+        eks = boto3.client("eks", region_name="us-west-2")
         response = eks.update_nodegroup_config(
             clusterName=req.cluster_name,
             nodegroupName=req.nodegroup_name,
@@ -132,12 +132,12 @@ def update_nodegroup_size(req: ScaleRequest) -> ScaleResponse:
         scale_response = ScaleResponse(
             success=False,
             message=f"Error occurred while updating nodegroup: {str(e)}",
-            nodegroup_update=None,
+            nodegroup_update={},
         )
     except Exception as e:
         scale_response = ScaleResponse(
             success=False,
             message=f"Unexpected error occurred while updating nodegroup: {str(e)}",
-            nodegroup_update=None,
+            nodegroup_update={},
         )
     return scale_response

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -186,7 +186,7 @@ async def process_prewarm_queue():
         request_info = await prewarm_requests_queue.get()
         desired_size = request_info["desired_size"]
         request_id = request_info["request_id"]
-        # await scale_nodes(desired_size, request_id)
+        await scale_nodes(desired_size, request_id)
         prewarm_requests_queue.task_done()
 
 

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -133,7 +133,7 @@ async def scale_nodes(desired_size: int, request_id: str):
 
 def is_valid_desired_size(func):
     @wraps(func)
-    def wrapper(req, *args, **kwargs):
+    async def wrapper(req, *args, **kwargs):
         try:
             eks = boto3.client("eks", region_name=REGION_NAME)
             response = eks.describe_nodegroup(
@@ -164,7 +164,7 @@ def is_valid_desired_size(func):
                     content={"message": message},
                 )
             else:
-                return func(req, *args, **kwargs)
+                return await func(req, *args, **kwargs)
         except botocore.exceptions.ClientError as e:
             message = f"Error occurred while checking desired size: {str(e)}"
             return JSONResponse(
@@ -197,7 +197,6 @@ async def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
         # Generate a unique request ID
         request_id = str(uuid.uuid4())
         ready_nodes = get_ready_nodes_in_daemonset()
-
         async with prewarm_requests_lock:
             prewarm_requests[request_id] = PrewarmRequestInfo(
                 status="Accepted",

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -1,11 +1,25 @@
-from fastapi import APIRouter, Query, HTTPException
-
-# from typing import Dict, Any
-from pydantic import BaseModel  # , Field, root_validator, validator
+from fastapi import APIRouter, HTTPException, BackgroundTasks
 import boto3
 import botocore
+from kubernetes import client, config
+from pydantic import BaseModel
+from typing import Dict
 from functools import wraps
+import os
+import asyncio
+import uuid
 
+
+prewarm_requests: Dict[str, Dict] = {}
+
+# Load the Kubernetes configuration
+config.load_incluster_config()
+
+REGION_NAME = os.environ.get("AWS_REGION_NAME")
+EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME")
+VERDI_NODE_GROUP_NAME = os.environ.get("VERDI_NODE_GROUP_NAME")
+VERDI_DAEMONSET_NAMESPACE = os.environ.get("VERDI_DAEMONSET_NAMESPACE")
+VERDI_DAEMONSET_NAME = os.environ.get("VERDI_DAEMONSET_NAME")
 
 router = APIRouter(
     prefix="/sps",
@@ -20,69 +34,119 @@ router = APIRouter(
 
 
 class PrewarmRequest(BaseModel):
-    cluster_name: str
-    node_group_name: str
     desired_size: int
 
 
 class PrewarmResponse(BaseModel):
     success: bool
     message: str
-    node_group_update: dict
+    prewarm_request_id: str
 
 
-# class PrewarmStatusRequest(BaseModel):
-#     prewarm_request_id: str
-#     cluster_name: str = Query(..., description="Name of the EKS cluster.")
-#     node_group_name: str = Query(..., description="Name of the EKS node group.")
+class PrewarmRequestStatusResponse(BaseModel):
+    status: str
+    desired_size: int
+    node_group_update: dict = None
+    error: str = None
 
 
-class PrewarmStatusResponse(BaseModel):
-    node_group_update: dict
+class ActiveNodesResponse(BaseModel):
+    num_active_nodes: int
 
 
 class HealthCheckResponse(BaseModel):
     message: str
 
 
+def get_active_nodes_in_daemonset() -> int:
+    v1 = client.CoreV1Api()
+    daemonset = v1.read_namespaced_daemon_set(
+        VERDI_DAEMONSET_NAME, VERDI_DAEMONSET_NAMESPACE
+    )
+    return daemonset.status.number_ready
+
+
+async def scale_nodes(desired_size: int, request_id: str):
+    try:
+        eks = boto3.client("eks", region_name=REGION_NAME)
+
+        while True:
+            response = eks.update_nodegroup_config(
+                clusterName=EKS_CLUSTER_NAME,
+                nodegroupName=VERDI_NODE_GROUP_NAME,
+                scalingConfig={"desiredSize": desired_size},
+            )
+            active_nodes = get_active_nodes_in_daemonset()
+            if active_nodes == desired_size:
+                prewarm_requests[request_id]["status"] = "Succeeded"
+                prewarm_requests[request_id]["node_group_update"] = response["update"]
+                break
+
+            prewarm_requests[request_id]["status"] = "Running"
+            prewarm_requests[request_id]["node_group_update"] = response["update"]
+            await asyncio.sleep(5)  # Check the DaemonSet status every 5 seconds
+
+    except Exception as e:
+        prewarm_requests[request_id]["status"] = "failed"
+        prewarm_requests[request_id]["error"] = str(e)
+
+
 def is_valid_desired_size(func):
     @wraps(func)
     def wrapper(req):
+        request_id = str(uuid.uuid4())  # Generate a unique request ID
+
+        # Store the failed prewarm request with the "failed" status
+        def store_failed_request(message):
+            prewarm_requests[request_id] = {
+                "status": "failed",
+                "desired_size": req.desired_size,
+                "error": message,
+            }
+
         try:
-            eks = boto3.client("eks", region_name="us-west-2")
+            eks = boto3.client("eks", region_name=REGION_NAME)
             response = eks.describe_nodegroup(
-                clusterName=req.cluster_name,
-                nodegroupName=req.node_group_name,
+                clusterName=EKS_CLUSTER_NAME,
+                nodegroupName=VERDI_NODE_GROUP_NAME,
             )
             node_group = response["nodegroup"]
             max_size = node_group["scalingConfig"]["maxSize"]
             min_size = node_group["scalingConfig"]["minSize"]
 
             if req.desired_size > max_size:
+                message = f"Desired size {req.desired_size} is larger than the node group's max size {max_size}"
+                store_failed_request(message)
                 return PrewarmResponse(
                     success=False,
-                    message=f"Desired size {req.desired_size} is larger than the node group's max size {max_size}",
-                    node_group_update={},
+                    message=message,
+                    prewarm_request_id=request_id,
                 )
             elif req.desired_size < min_size:
+                message = f"Desired size {req.desired_size} is smaller than the node group's min size {min_size}"
+                store_failed_request(message)
                 return PrewarmResponse(
                     success=False,
-                    message=f"Desired size {req.desired_size} is smaller than the node group's min size {min_size}",
-                    node_group_update={},
+                    message=message,
+                    prewarm_request_id=request_id,
                 )
             else:
-                return func(req)
+                return func(req, request_id)
         except botocore.exceptions.ClientError as e:
+            message = f"Error occurred while checking desired size: {str(e)}"
+            store_failed_request(message)
             return PrewarmResponse(
                 success=False,
-                message=f"Error occurred while checking desired size: {str(e)}",
-                node_group_update={},
+                message=message,
+                prewarm_request_id=request_id,
             )
         except Exception as e:
+            message = f"Unexpected error occurred while checking desired size: {str(e)}"
+            store_failed_request(message)
             return PrewarmResponse(
                 success=False,
-                message=f"Unexpected error occurred while checking desired size: {str(e)}",
-                node_group_update={},
+                message=message,
+                prewarm_request_id=request_id,
             )
 
     return wrapper
@@ -90,55 +154,82 @@ def is_valid_desired_size(func):
 
 @router.post("/prewarm")
 @is_valid_desired_size
-def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
+def create_prewarm_request(
+    req: PrewarmRequest, request_id: str, background_tasks: BackgroundTasks
+) -> PrewarmResponse:
     try:
-        eks = boto3.client("eks", region_name="us-west-2")
-        response = eks.update_nodegroup_config(
-            clusterName=req.cluster_name,
-            nodegroupName=req.node_group_name,
-            scalingConfig={"desiredSize": req.desired_size},
-        )
+        # Store the prewarm request information
+        prewarm_requests[request_id] = {
+            "status": "in-progress",
+            "desired_size": req.desired_size,
+        }
+
+        # Start the scale_nodes function as a background task
+        background_tasks.add_task(scale_nodes, req.desired_size, request_id)
+
         prewarm_response = PrewarmResponse(
             success=True,
-            message="Node group updated successfully",
-            node_group_update=response["update"],
+            message=f"Prewarm request created with ID {request_id}",
+            prewarm_request_id=request_id,
         )
-    except botocore.exceptions.ClientError as e:
-        prewarm_response = PrewarmResponse(
-            success=False,
-            message=f"Error occurred while updating node group: {str(e)}",
-            node_group_update={},
-        )
+
     except Exception as e:
         prewarm_response = PrewarmResponse(
             success=False,
-            message=f"Unexpected error occurred while updating node group: {str(e)}",
-            node_group_update={},
+            message=f"Unexpected error occurred while creating prewarm request: {str(e)}",
+            prewarm_request_id=None,
         )
+
     return prewarm_response
 
 
+# @router.get("/prewarm/{prewarm_request_id}")
+# async def get_prewarm_status(prewarm_request_id: str) -> PrewarmStatusResponse:
+#     try:
+#         eks = boto3.client("eks", region_name=REGION_NAME)
+#         response = eks.describe_update(
+#             name=EKS_CLUSTER_NAME,
+#             nodegroupName=VERDI_NODE_GROUP_NAME,
+#             updateId=prewarm_request_id,
+#         )
+#         prewarm_status_response = PrewarmStatusResponse(
+#             node_group_update=response["update"],
+#         )
+#     except botocore.exceptions.ClientError as e:
+#         raise HTTPException(status_code=400, detail=f"Bad request: {str(e)}")
+#     except Exception as e:
+#         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+#     return prewarm_status_response
+
+
 @router.get("/prewarm/{prewarm_request_id}")
-async def get_prewarm_status(
-    prewarm_request_id: str,
-    cluster_name: str = Query(..., description="Name of the EKS cluster"),
-    node_group_name: str = Query(..., description="Name of the EKS node group"),
-) -> PrewarmStatusResponse:
+async def get_prewarm_status(prewarm_request_id: str) -> PrewarmRequestStatusResponse:
+    if prewarm_request_id not in prewarm_requests:
+        raise HTTPException(status_code=404, detail="Prewarm request not found")
+
+    prewarm_request = prewarm_requests[prewarm_request_id]
+
+    prewarm_status_response = PrewarmRequestStatusResponse(
+        status=prewarm_request["status"],
+        desired_size=prewarm_request["desired_size"],
+        node_group_update=prewarm_request.get("node_group_update"),
+        error=prewarm_request.get("error"),
+    )
+
+    return prewarm_status_response
+
+
+@router.get("/active-nodes")
+async def active_nodes() -> ActiveNodesResponse:
     try:
-        eks = boto3.client("eks", region_name="us-west-2")
-        response = eks.describe_update(
-            name=cluster_name,
-            nodegroupName=node_group_name,
-            updateId=prewarm_request_id,
+        num_active_nodes = get_active_nodes_in_daemonset()
+        active_nodes_response = ActiveNodesResponse(
+            num_active_nodes=num_active_nodes,
         )
-        prewarm_status_response = PrewarmStatusResponse(
-            node_group_update=response["update"],
-        )
-    except botocore.exceptions.ClientError as e:
-        raise HTTPException(status_code=400, detail=f"Bad request: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
-    return prewarm_status_response
+
+    return active_nodes_response
 
 
 @router.get("/health-check")

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -135,9 +135,9 @@ async def get_prewarm_status(
             node_group_update=response["update"],
         )
     except botocore.exceptions.ClientError as e:
-        raise HTTPException(status_code=400, detail="Bad request")
+        raise HTTPException(status_code=400, detail=f"Bad request: {str(e)}")
     except Exception as e:
-        raise HTTPException(status_code=500, detail="Internal server error")
+        raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
     return prewarm_status_response
 
 

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -94,7 +94,7 @@ async def scale_nodes(desired_size: int, request_id: str):
 
 def is_valid_desired_size(func):
     @wraps(func)
-    def wrapper(req):
+    def wrapper(req, *args, **kwargs):
         try:
             eks = boto3.client("eks", region_name=REGION_NAME)
             response = eks.describe_nodegroup(
@@ -118,7 +118,7 @@ def is_valid_desired_size(func):
                     content={"message": message},
                 )
             else:
-                return func(req)
+                return func(req, *args, **kwargs)
         except botocore.exceptions.ClientError as e:
             message = f"Error occurred while checking desired size: {str(e)}"
             return JSONResponse(

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -1,16 +1,16 @@
-from fastapi import APIRouter, HTTPException, BackgroundTasks
-from fastapi.responses import JSONResponse
-import boto3
-import botocore
-from kubernetes import client, config
-from pydantic import BaseModel, Field
-from typing import Dict, List
-from functools import wraps
-import os
 import asyncio
+import os
 import uuid
 from datetime import datetime
+from functools import wraps
+from typing import Dict, List
 
+import boto3
+import botocore
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse
+from kubernetes import client, config
+from pydantic import BaseModel, Field
 
 # Load the Kubernetes configuration
 config.load_incluster_config()

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter
-from pydantic import BaseModel
+from fastapi import APIRouter, Query
+
+# from typing import Dict, Any
+from pydantic import BaseModel  # , Field, root_validator, validator
 import boto3
 import botocore
 from functools import wraps
@@ -18,61 +20,29 @@ router = APIRouter(
 
 
 class PrewarmRequest(BaseModel):
-    num_nodes: int
-
-
-class PrewarmResponse(BaseModel):
-    success: bool
-    message: str
-    request_id: str
-
-
-class HealthCheckResponse(BaseModel):
-    message: str
-
-
-class ScaleRequest(BaseModel):
     cluster_name: str
     node_group_name: str
     desired_size: int
 
 
-class ScaleResponse(BaseModel):
+class PrewarmResponse(BaseModel):
     success: bool
     message: str
     node_group_update: dict
 
 
-@router.post("/prewarm")
-async def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
-    return {
-        "success": True,
-        "message": "Prewarm is not implemented, this request has no effect.",
-        "request_id": f"{req.num_nodes}",
-    }
+# class PrewarmStatusRequest(BaseModel):
+#     prewarm_request_id: str
+#     cluster_name: str = Query(..., description="Name of the EKS cluster.")
+#     node_group_name: str = Query(..., description="Name of the EKS node group.")
 
 
-@router.get("/prewarm/{request_id}")
-async def get_prewarm_request(request_id: str) -> PrewarmResponse:
-    return {
-        "success": True,
-        "message": f"Status for prewarm request ID {request_id}.",
-        "request_id": request_id,
-    }
+class PrewarmStatusResponse(BaseModel):
+    node_group_update: dict
 
 
-@router.delete("/prewarm/{request_id}")
-async def delete_prewarm_request(request_id: str) -> PrewarmResponse:
-    return {
-        "success": True,
-        "message": f"Prewarm request ID {request_id} deleted.",
-        "request_id": request_id,
-    }
-
-
-@router.get("/health-check")
-async def health_check() -> HealthCheckResponse:
-    return {"message": "The U-SPS On-Demand API is running and accessible"}
+class HealthCheckResponse(BaseModel):
+    message: str
 
 
 def is_valid_desired_size(func):
@@ -89,13 +59,13 @@ def is_valid_desired_size(func):
             min_size = node_group["scalingConfig"]["minSize"]
 
             if req.desired_size > max_size:
-                return ScaleResponse(
+                return PrewarmResponse(
                     success=False,
                     message=f"Desired size {req.desired_size} is larger than the node group's max size {max_size}",
                     node_group_update={},
                 )
             elif req.desired_size < min_size:
-                return ScaleResponse(
+                return PrewarmResponse(
                     success=False,
                     message=f"Desired size {req.desired_size} is smaller than the node group's min size {min_size}",
                     node_group_update={},
@@ -103,13 +73,13 @@ def is_valid_desired_size(func):
             else:
                 return func(req)
         except botocore.exceptions.ClientError as e:
-            return ScaleResponse(
+            return PrewarmResponse(
                 success=False,
                 message=f"Error occurred while checking desired size: {str(e)}",
                 node_group_update={},
             )
         except Exception as e:
-            return ScaleResponse(
+            return PrewarmResponse(
                 success=False,
                 message=f"Unexpected error occurred while checking desired size: {str(e)}",
                 node_group_update={},
@@ -118,9 +88,9 @@ def is_valid_desired_size(func):
     return wrapper
 
 
-@router.post("/scale")
+@router.post("/prewarm")
 @is_valid_desired_size
-def update_node_group_size(req: ScaleRequest) -> ScaleResponse:
+def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
     try:
         eks = boto3.client("eks", region_name="us-west-2")
         response = eks.update_nodegroup_config(
@@ -128,21 +98,53 @@ def update_node_group_size(req: ScaleRequest) -> ScaleResponse:
             nodegroupName=req.node_group_name,
             scalingConfig={"desiredSize": req.desired_size},
         )
-        scale_response = ScaleResponse(
+        prewarm_response = PrewarmResponse(
             success=True,
             message="Node group updated successfully",
             node_group_update=response["update"],
         )
     except botocore.exceptions.ClientError as e:
-        scale_response = ScaleResponse(
+        prewarm_response = PrewarmResponse(
             success=False,
             message=f"Error occurred while updating node group: {str(e)}",
             node_group_update={},
         )
     except Exception as e:
-        scale_response = ScaleResponse(
+        prewarm_response = PrewarmResponse(
             success=False,
             message=f"Unexpected error occurred while updating node group: {str(e)}",
             node_group_update={},
         )
-    return scale_response
+    return prewarm_response
+
+
+@router.get("/prewarm/{prewarm_request_id}")
+async def get_prewarm_status(
+    prewarm_request_id: str,
+    cluster_name: str = Query(..., description="Name of the EKS cluster"),
+    node_group_name: str = Query(..., description="Name of the EKS node group"),
+) -> PrewarmStatusResponse:
+    try:
+        eks = boto3.client("eks", region_name="us-west-2")
+        response = eks.describe_update(
+            name=cluster_name,
+            nodegroupName=node_group_name,
+            updateId=prewarm_request_id,
+        )
+        prewarm_status_response = PrewarmStatusResponse(
+            node_group_update=response["update"],
+        )
+    except botocore.exceptions.ClientError as e:
+        prewarm_status_response = PrewarmStatusResponse(
+            node_group_update={},
+        )
+    except Exception as e:
+        prewarm_status_response = PrewarmStatusResponse(
+            node_group_update={},
+        )
+    return prewarm_status_response
+
+
+@router.get("/health-check")
+async def health_check() -> HealthCheckResponse:
+    return {"message": "The U-SPS On-Demand API is running and accessible"}

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -59,7 +59,7 @@ class HealthCheckResponse(BaseModel):
 
 
 def get_active_nodes_in_daemonset() -> int:
-    v1 = client.CoreV1Api()
+    v1 = client.AppsV1Api()
     daemonset = v1.read_namespaced_daemon_set(
         VERDI_DAEMONSET_NAME, VERDI_DAEMONSET_NAMESPACE
     )

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -4,7 +4,7 @@ import boto3
 import botocore
 from kubernetes import client, config
 from pydantic import BaseModel, Field
-from typing import Dict, List
+from typing import Dict, List, Optional
 from functools import wraps
 import os
 import asyncio
@@ -40,7 +40,7 @@ class PrewarmRequest(BaseModel):
 class PrewarmResponse(BaseModel):
     success: bool
     message: str
-    prewarm_request_id: str
+    prewarm_request_id: Optional[str]
 
 
 class PrewarmRequestInfo(BaseModel):
@@ -221,7 +221,6 @@ async def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
         prewarm_response = PrewarmResponse(
             success=False,
             message=f"Unexpected error occurred while creating prewarm request: {str(e)}",
-            prewarm_request_id=None,
         )
 
     return prewarm_response

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -191,10 +191,8 @@ async def process_prewarm_queue():
 
 
 @router.post("/prewarm")
-# @is_valid_desired_size
-async def create_prewarm_request(
-    req: PrewarmRequest, background_tasks: BackgroundTasks
-) -> PrewarmResponse:
+@is_valid_desired_size
+async def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
     try:
         # Generate a unique request ID
         request_id = str(uuid.uuid4())
@@ -214,9 +212,6 @@ async def create_prewarm_request(
                 "request_id": request_id,
             }
         )
-
-        # Add process_prewarm_queue as a background task
-        background_tasks.add_task(process_prewarm_queue)
 
         prewarm_response = PrewarmResponse(
             success=True,

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, HTTPException
 
 # from typing import Dict, Any
 from pydantic import BaseModel  # , Field, root_validator, validator
@@ -135,13 +135,9 @@ async def get_prewarm_status(
             node_group_update=response["update"],
         )
     except botocore.exceptions.ClientError as e:
-        prewarm_status_response = PrewarmStatusResponse(
-            node_group_update={},
-        )
+        raise HTTPException(status_code=400, detail="Bad request")
     except Exception as e:
-        prewarm_status_response = PrewarmStatusResponse(
-            node_group_update={},
-        )
+        raise HTTPException(status_code=500, detail="Internal server error")
     return prewarm_status_response
 
 

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 
 # Load the Kubernetes configuration
-# config.load_incluster_config()
+config.load_incluster_config()
 
 REGION_NAME = os.environ.get("AWS_REGION_NAME")
 EKS_CLUSTER_NAME = os.environ.get("EKS_CLUSTER_NAME")

--- a/app/routers/prewarm.py
+++ b/app/routers/prewarm.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
+from kubernetes import client, config
 
 router = APIRouter(
     prefix="/sps",
@@ -12,26 +13,33 @@ router = APIRouter(
     },
 )
 
+# Assuming this code is running inside a Kubernetes pod
+config.load_incluster_config()
+
+# Initialize the Kubernetes API client
+v1 = client.AppsV1Api()
+
+
 class PrewarmRequest(BaseModel):
     num_nodes: int
+
 
 class PrewarmResponse(BaseModel):
     success: bool
     message: str
     request_id: str
 
+
 class HealthCheckResponse(BaseModel):
     message: str
 
 
 @router.post("/prewarm")
-async def create_prewarm_request(
-    req: PrewarmRequest
-) -> PrewarmResponse:
+async def create_prewarm_request(req: PrewarmRequest) -> PrewarmResponse:
     return {
         "success": True,
         "message": "Prewarm is not implemented, this request has no effect.",
-        "request_id": f"{req.num_nodes}"
+        "request_id": f"{req.num_nodes}",
     }
 
 
@@ -40,17 +48,41 @@ async def get_prewarm_request(request_id: str) -> PrewarmResponse:
     return {
         "success": True,
         "message": f"Status for prewarm request ID {request_id}.",
-        "request_id": request_id
+        "request_id": request_id,
     }
+
 
 @router.delete("/prewarm/{request_id}")
 async def delete_prewarm_request(request_id: str) -> PrewarmResponse:
     return {
         "success": True,
         "message": f"Prewarm request ID {request_id} deleted.",
-        "request_id": request_id
+        "request_id": request_id,
     }
+
 
 @router.get("/health-check")
 async def health_check() -> HealthCheckResponse:
     return {"message": "The U-SPS On-Demand API is running and accessible"}
+
+
+@router.post("/scale-up")
+async def scale_up(num_nodes: int) -> dict:
+    daemonset_name = "verdi"
+    daemonset = v1.read_namespaced_daemon_set(daemonset_name, "default")
+    daemonset.spec.replicas = num_nodes
+    v1.patch_namespaced_daemon_set(
+        name=daemonset_name, namespace="default", body=daemonset
+    )
+    return {"message": f"Scaled {daemonset_name} to {num_nodes} replicas"}
+
+
+@router.post("/scale-down")
+async def scale_down(num_nodes: int) -> dict:
+    daemonset_name = "verdi"
+    daemonset = v1.read_namespaced_daemon_set(daemonset_name, "default")
+    daemonset.spec.replicas = num_nodes
+    v1.patch_namespaced_daemon_set(
+        name=daemonset_name, namespace="default", body=daemonset
+    )
+    return {"message": f"Scaled {daemonset_name} to {num_nodes} replicas"}

--- a/app/test/test_sps_api.py
+++ b/app/test/test_sps_api.py
@@ -6,35 +6,41 @@ from ..main import app
 
 client = TestClient(app)
 
+
 @pytest.fixture
 def test_client():
     return client
 
-@pytest.fixture
-def prewarm_request_id(test_client):
-    request = {'num_nodes': 10}
-    resp = test_client.post('/sps/prewarm', json=request)
-    return resp.json()['request_id']
-    
+
 def test_healthcheck(test_client):
-    resp = test_client.get(f'/sps/health-check')
+    resp = test_client.get(f"/sps/health-check")
     assert resp.status_code == 200
+
 
 def test_create_prewarm(test_client):
-    request = {'num_nodes': 10}
-    resp = test_client.post('/sps/prewarm', json=request)
+    request = {
+        "cluster_name": "cluster-name",
+        "node_group_name": "node-group-name",
+        "desired_size": 5,
+    }
+    resp = test_client.post("/sps/prewarm", json=request)
     assert resp.status_code == 200
-    assert 'message' in resp.json()
-    assert 'request_id' in resp.json()
+    assert "success" in resp.json()
+    assert "message" in resp.json()
+    assert "node_group_update" in resp.json()
 
-def test_get_prewarm(prewarm_request_id, test_client):
-    resp = test_client.get(f'/sps/prewarm/{prewarm_request_id}')
-    assert resp.status_code == 200
-    assert 'message' in resp.json()
-    assert 'request_id' in resp.json()
 
-def test_delete_prewarm(prewarm_request_id, test_client):
-    resp = test_client.delete(f'/sps/prewarm/{prewarm_request_id}')
+def test_get_prewarm_status(test_client):
+    # query_params = {
+    #     "cluster_name": "unity-test-sps-hysds-eks-multinode",
+    #     "node_group_name": "defaultgroupNodeGroup",
+    # }
+    # prewarm_request_id = "901e88da-c9f9-3f33-855c-142ae66749f3"
+    query_params = {
+        "cluster_name": "cluster-name",
+        "node_group_name": "node-group-name",
+    }
+    prewarm_request_id = "prewarm-request-id"
+    resp = test_client.get(f"/sps/prewarm/{prewarm_request_id}", params=query_params)
     assert resp.status_code == 200
-    assert 'message' in resp.json()
-    assert 'request_id' in resp.json()
+    assert "node_group_update" in resp.json()

--- a/app/test/test_sps_api.py
+++ b/app/test/test_sps_api.py
@@ -31,16 +31,39 @@ def test_create_prewarm(test_client):
 
 
 def test_get_prewarm_status(test_client):
-    # query_params = {
-    #     "cluster_name": "unity-test-sps-hysds-eks-multinode",
-    #     "node_group_name": "defaultgroupNodeGroup",
-    # }
-    # prewarm_request_id = "901e88da-c9f9-3f33-855c-142ae66749f3"
     query_params = {
-        "cluster_name": "cluster-name",
-        "node_group_name": "node-group-name",
+        "cluster_name": "unity-test-sps-hysds-eks-multinode",
+        "node_group_name": "VerdiNodeGroup",
     }
-    prewarm_request_id = "prewarm-request-id"
+    # prewarm_request_id = "237a3dc8-441d-3ef6-9ebf-2ec7c13ea522"
+    prewarm_request_id = "5814f574-02a7-3de3-8d23-cdfa30a5995d"
+    # query_params = {
+    #     "cluster_name": "cluster-name",
+    #     "node_group_name": "node-group-name",
+    # }
+    # prewarm_request_id = "prewarm-request-id"
     resp = test_client.get(f"/sps/prewarm/{prewarm_request_id}", params=query_params)
+    full_url = test_client.get(
+        f"/sps/prewarm/{prewarm_request_id}", params=query_params
+    ).request.url
+    print(full_url)
+    print(resp.json())
+    assert resp.status_code == 200
+    assert "node_group_update" in resp.json()
+
+
+import requests
+
+
+def test_get_prewarm_status_requests(test_client):
+    query_params = {
+        "cluster_name": "unity-test-sps-hysds-eks-multinode",
+        "node_group_name": "VerdiNodeGroup",
+    }
+    prewarm_request_id = "5814f574-02a7-3de3-8d23-cdfa30a5995d"
+    url = f"http://a769b73032a074a28b3b0aab0d60d1fd-427874917.us-west-2.elb.amazonaws.com:5002/sps/prewarm/{prewarm_request_id}"
+    resp = requests.get(url, params=query_params)
+    print(resp.url)
+    print(resp.json())
     assert resp.status_code == 200
     assert "node_group_update" in resp.json()

--- a/app/test/test_sps_api.py
+++ b/app/test/test_sps_api.py
@@ -6,64 +6,35 @@ from ..main import app
 
 client = TestClient(app)
 
-
 @pytest.fixture
 def test_client():
     return client
 
-
+@pytest.fixture
+def prewarm_request_id(test_client):
+    request = {'num_nodes': 10}
+    resp = test_client.post('/sps/prewarm', json=request)
+    return resp.json()['request_id']
+    
 def test_healthcheck(test_client):
-    resp = test_client.get(f"/sps/health-check")
+    resp = test_client.get(f'/sps/health-check')
     assert resp.status_code == 200
-
 
 def test_create_prewarm(test_client):
-    request = {
-        "cluster_name": "cluster-name",
-        "node_group_name": "node-group-name",
-        "desired_size": 5,
-    }
-    resp = test_client.post("/sps/prewarm", json=request)
+    request = {'num_nodes': 10}
+    resp = test_client.post('/sps/prewarm', json=request)
     assert resp.status_code == 200
-    assert "success" in resp.json()
-    assert "message" in resp.json()
-    assert "node_group_update" in resp.json()
+    assert 'message' in resp.json()
+    assert 'request_id' in resp.json()
 
-
-def test_get_prewarm_status(test_client):
-    query_params = {
-        "cluster_name": "unity-test-sps-hysds-eks-multinode",
-        "node_group_name": "VerdiNodeGroup",
-    }
-    # prewarm_request_id = "237a3dc8-441d-3ef6-9ebf-2ec7c13ea522"
-    prewarm_request_id = "5814f574-02a7-3de3-8d23-cdfa30a5995d"
-    # query_params = {
-    #     "cluster_name": "cluster-name",
-    #     "node_group_name": "node-group-name",
-    # }
-    # prewarm_request_id = "prewarm-request-id"
-    resp = test_client.get(f"/sps/prewarm/{prewarm_request_id}", params=query_params)
-    full_url = test_client.get(
-        f"/sps/prewarm/{prewarm_request_id}", params=query_params
-    ).request.url
-    print(full_url)
-    print(resp.json())
+def test_get_prewarm(prewarm_request_id, test_client):
+    resp = test_client.get(f'/sps/prewarm/{prewarm_request_id}')
     assert resp.status_code == 200
-    assert "node_group_update" in resp.json()
+    assert 'message' in resp.json()
+    assert 'request_id' in resp.json()
 
-
-import requests
-
-
-def test_get_prewarm_status_requests(test_client):
-    query_params = {
-        "cluster_name": "unity-test-sps-hysds-eks-multinode",
-        "node_group_name": "VerdiNodeGroup",
-    }
-    prewarm_request_id = "5814f574-02a7-3de3-8d23-cdfa30a5995d"
-    url = f"http://a769b73032a074a28b3b0aab0d60d1fd-427874917.us-west-2.elb.amazonaws.com:5002/sps/prewarm/{prewarm_request_id}"
-    resp = requests.get(url, params=query_params)
-    print(resp.url)
-    print(resp.json())
+def test_delete_prewarm(prewarm_request_id, test_client):
+    resp = test_client.delete(f'/sps/prewarm/{prewarm_request_id}')
     assert resp.status_code == 200
-    assert "node_group_update" in resp.json()
+    assert 'message' in resp.json()
+    assert 'request_id' in resp.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ starlette==0.25.0
 tomli==2.0.1
 typing_extensions==4.5.0
 uvicorn==0.20.0
+kubernetes==26.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ typing_extensions==4.5.0
 uvicorn==0.20.0
 boto3==1.26.94
 botocore==1.29.94
+kubernetes==26.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,5 @@ starlette==0.25.0
 tomli==2.0.1
 typing_extensions==4.5.0
 uvicorn==0.20.0
-kubernetes==26.1.0
+boto3==1.26.94
+botocore==1.29.94


### PR DESCRIPTION
## Purpose

- This PR updates the SPS API to be able to dynamically scale the number of Verdi worker nodes in the Kubernetes cluster.

## Proposed Changes
- Adds real implementation to the existing stubbed endpoints.

## Issues
- Resolves https://github.com/unity-sds/unity-sps-prototype/issues/170
- Resolves https://github.com/unity-sds/unity-sps-prototype/issues/171
- Gets us closer to closing:
  - https://github.com/unity-sds/unity-sps-prototype/issues/141
    - Still need to implement scaling triggers (CPU, Memory, Job Queue)
- Resolves https://github.com/unity-sds/unity-sps-prototype/issues/142

## Testing
- The manual verification process followed this procedure in GitBook:
  - [Manual verification/testing of the SPS API on-demand prewarm-related features](https://unity-sds.gitbook.io/docs/~/changes/TMwRbPjXYqq9MCfmRi31/developer-docs/science-processing/docs/developers-guide/manual-verification-testing-the-sps-prewarm-api)
- [Smoke Test in MCP Test (testing with the L1B process)](https://github.com/unity-sds/unity-sps-prototype/actions/runs/4622727557)
- [Smoke Test in MCP Dev (testing with the L1B process)](https://github.com/unity-sds/unity-sps-prototype/actions/runs/4622733269)

## Housekeeping
- This PR is related to the following PRs:
  - https://github.com/unity-sds/ades_wpst/pull/11
  - https://github.com/unity-sds/unity-sps-prototype/pull/176
- [The SPS API documentation was updated on GitBook](https://unity-sds.gitbook.io/docs/~/changes/TMwRbPjXYqq9MCfmRi31/developer-docs/science-processing/docs/users-guide/unity-sps-api) 